### PR TITLE
Fix custom kernel suffix input reference in fastbuild workflows

### DIFF
--- a/.github/workflows/fastbuild_6.6.118.yml
+++ b/.github/workflows/fastbuild_6.6.118.yml
@@ -546,7 +546,7 @@ jobs:
             for f in ./common/scripts/setlocalversion; do
               sed -i "\$s|echo \"\\\$res\"|echo \"-${{ github.event.inputs.kernel_suffix }}\"|" "$f"
             done
-            sudo sed -i 's/-4k/-${{ github.event.inputs.KERNEL_SUFFIX }}/g' ./common/arch/arm64/configs/gki_defconfig
+            sudo sed -i 's/-4k/-${{ github.event.inputs.kernel_suffix }}/g' ./common/arch/arm64/configs/gki_defconfig
           else
             echo "当前内核版本后缀：${{ env.KERNEL_NAME }}"
             for f in ./common/scripts/setlocalversion; do

--- a/.github/workflows/fastbuild_6.6.30.yml
+++ b/.github/workflows/fastbuild_6.6.30.yml
@@ -546,7 +546,7 @@ jobs:
             for f in ./common/scripts/setlocalversion; do
               sed -i "\$s|echo \"\\\$res\"|echo \"-${{ github.event.inputs.kernel_suffix }}\"|" "$f"
             done
-            sudo sed -i 's/-4k/-${{ github.event.inputs.KERNEL_SUFFIX }}/g' ./common/arch/arm64/configs/gki_defconfig
+            sudo sed -i 's/-4k/-${{ github.event.inputs.kernel_suffix }}/g' ./common/arch/arm64/configs/gki_defconfig
           else
             echo "当前内核版本后缀：${{ env.KERNEL_NAME }}"
             for f in ./common/scripts/setlocalversion; do

--- a/.github/workflows/fastbuild_6.6.50.yml
+++ b/.github/workflows/fastbuild_6.6.50.yml
@@ -546,7 +546,7 @@ jobs:
             for f in ./common/scripts/setlocalversion; do
               sed -i "\$s|echo \"\\\$res\"|echo \"-${{ github.event.inputs.kernel_suffix }}\"|" "$f"
             done
-            sudo sed -i 's/-4k/-${{ github.event.inputs.KERNEL_SUFFIX }}/g' ./common/arch/arm64/configs/gki_defconfig
+            sudo sed -i 's/-4k/-${{ github.event.inputs.kernel_suffix }}/g' ./common/arch/arm64/configs/gki_defconfig
           else
             echo "当前内核版本后缀：${{ env.KERNEL_NAME }}"
             for f in ./common/scripts/setlocalversion; do

--- a/.github/workflows/fastbuild_6.6.56.yml
+++ b/.github/workflows/fastbuild_6.6.56.yml
@@ -546,7 +546,7 @@ jobs:
             for f in ./common/scripts/setlocalversion; do
               sed -i "\$s|echo \"\\\$res\"|echo \"-${{ github.event.inputs.kernel_suffix }}\"|" "$f"
             done
-            sudo sed -i 's/-4k/-${{ github.event.inputs.KERNEL_SUFFIX }}/g' ./common/arch/arm64/configs/gki_defconfig
+            sudo sed -i 's/-4k/-${{ github.event.inputs.kernel_suffix }}/g' ./common/arch/arm64/configs/gki_defconfig
           else
             echo "当前内核版本后缀：${{ env.KERNEL_NAME }}"
             for f in ./common/scripts/setlocalversion; do

--- a/.github/workflows/fastbuild_6.6.57.yml
+++ b/.github/workflows/fastbuild_6.6.57.yml
@@ -546,7 +546,7 @@ jobs:
             for f in ./common/scripts/setlocalversion; do
               sed -i "\$s|echo \"\\\$res\"|echo \"-${{ github.event.inputs.kernel_suffix }}\"|" "$f"
             done
-            sudo sed -i 's/-4k/-${{ github.event.inputs.KERNEL_SUFFIX }}/g' ./common/arch/arm64/configs/gki_defconfig
+            sudo sed -i 's/-4k/-${{ github.event.inputs.kernel_suffix }}/g' ./common/arch/arm64/configs/gki_defconfig
           else
             echo "当前内核版本后缀：${{ env.KERNEL_NAME }}"
             for f in ./common/scripts/setlocalversion; do

--- a/.github/workflows/fastbuild_6.6.66.yml
+++ b/.github/workflows/fastbuild_6.6.66.yml
@@ -546,7 +546,7 @@ jobs:
             for f in ./common/scripts/setlocalversion; do
               sed -i "\$s|echo \"\\\$res\"|echo \"-${{ github.event.inputs.kernel_suffix }}\"|" "$f"
             done
-            sudo sed -i 's/-4k/-${{ github.event.inputs.KERNEL_SUFFIX }}/g' ./common/arch/arm64/configs/gki_defconfig
+            sudo sed -i 's/-4k/-${{ github.event.inputs.kernel_suffix }}/g' ./common/arch/arm64/configs/gki_defconfig
           else
             echo "当前内核版本后缀：${{ env.KERNEL_NAME }}"
             for f in ./common/scripts/setlocalversion; do

--- a/.github/workflows/fastbuild_6.6.89.yml
+++ b/.github/workflows/fastbuild_6.6.89.yml
@@ -546,7 +546,7 @@ jobs:
             for f in ./common/scripts/setlocalversion; do
               sed -i "\$s|echo \"\\\$res\"|echo \"-${{ github.event.inputs.kernel_suffix }}\"|" "$f"
             done
-            sudo sed -i 's/-4k/-${{ github.event.inputs.KERNEL_SUFFIX }}/g' ./common/arch/arm64/configs/gki_defconfig
+            sudo sed -i 's/-4k/-${{ github.event.inputs.kernel_suffix }}/g' ./common/arch/arm64/configs/gki_defconfig
           else
             echo "当前内核版本后缀：${{ env.KERNEL_NAME }}"
             for f in ./common/scripts/setlocalversion; do

--- a/.github/workflows/fastbuild_6.6.89_mtk.yml
+++ b/.github/workflows/fastbuild_6.6.89_mtk.yml
@@ -546,7 +546,7 @@ jobs:
             for f in ./common/scripts/setlocalversion; do
               sed -i "\$s|echo \"\\\$res\"|echo \"-${{ github.event.inputs.kernel_suffix }}\"|" "$f"
             done
-            sudo sed -i 's/-4k/-${{ github.event.inputs.KERNEL_SUFFIX }}/g' ./common/arch/arm64/configs/gki_defconfig
+            sudo sed -i 's/-4k/-${{ github.event.inputs.kernel_suffix }}/g' ./common/arch/arm64/configs/gki_defconfig
           else
             echo "当前内核版本后缀：${{ env.KERNEL_NAME }}"
             for f in ./common/scripts/setlocalversion; do


### PR DESCRIPTION
## Summary
All 8 `fastbuild_*.yml` workflows referenced the workflow input as
`${{ github.event.inputs.KERNEL_SUFFIX }}` (line 549, the
`添加制作名称` step). The actual input is named `kernel_suffix`
(lowercase, declared at line 93 of each workflow). GitHub Actions
expressions are case-sensitive, so `KERNEL_SUFFIX` expands to an empty
string and the sed becomes `s/-4k/-/g` — when a custom kernel suffix is
provided, the `-4k` marker in `gki_defconfig` is silently dropped
instead of being replaced with the suffix.

The zip/release naming already used the correct `kernel_suffix`
input, so the bug only affected the defconfig version string.

Changed files: fastbuild_6.6.30/50/56/57/66/89/118/89_mtk.yml
(each a single-line fix).

## Test plan
- `python3` YAML parse of all workflows passes.
- Dispatched the 6.6.118 build workflow on this fork (run
  31016770987) with default inputs: completed successfully
  (conclusion=success, release created).